### PR TITLE
CD pipeline triggered from release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,11 @@
 version: 2
 jobs:
-  build:
+  Run tests on circleCI server:
     docker:
         - image: circleci/node
     steps:
       - checkout
       - setup_remote_docker
-      - add_ssh_keys:
-          fingerprints:
-            - "d4:22:e0:82:69:3b:81:31:42:e1:68:75:2e:75:4b:d5"
 
       - run: 
           name: Build docker images
@@ -23,6 +20,38 @@ jobs:
             echo "Setting up environment and running py-tests...."
             echo "yes" | docker-compose -f ./dockerfiles/docker-compose-test.yml up -d
 
+  Deploy to digital ocean:
+    docker:
+      - image: cimg/base:2020.01
+    branches:
+      - release
+    steps:
+      - checkout
+      - setup_remote_docker
+      - add_ssh_keys:
+          fingerprints:
+            - "d4:22:e0:82:69:3b:81:31:42:e1:68:75:2e:75:4b:d5"
+      - run: 
+          name: Build and push docker images to Dockerhub
+          command: |
+            echo "Logging in to Dockerhub..."
+            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+
+            echo "Building images..."
+            docker build -t $DOCKER_USERNAME/minitwit-app -f ./dockerfiles/Dockerfile-minitwit .
+
+            echo "Pushing images..."
+            docker push $DOCKER_USERNAME/minitwit-app:latest
+
+     - run:
+         name: Deploy to Digital Ocean Server via Docker
+         command: |
+           scp -r ./dockerfiles/* ${MT_USER}@${MT_SERVER}:/minitwit/dockerfiles/ \
+        #    ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
+        #    "source /root/.bash_profile && \
+        #    cd /minitwit && \
+        #    docker-compose -f ./dockerfiles/ pull && \
+        #    docker-compose -f ./dockerfiles/ up -d"
 
     # ----------------- TEMP: (WIP)
             # docker run -it --rm --network=minitwit-network $DOCKER_USERNAME/minitwit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,4 +70,4 @@ workflows:
             - build
           filters:
             branches:
-              only: deployment_from_release
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
+
 jobs:
+
   build:
-    name: Run tests on circleCI test server
     docker:
         - image: circleci/node
     steps:
@@ -24,8 +25,6 @@ jobs:
   deploy:
     docker:
         - image: cimg/base:2020.01
-    branches:
-        - deployment_from_release
     steps:
       - checkout
       - setup_remote_docker
@@ -53,6 +52,20 @@ jobs:
         #    cd /minitwit && \
         #    docker-compose -f ./dockerfiles/ pull && \
         #    docker-compose -f ./dockerfiles/ up -d"
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: deployment_from_release
+
+
 
     # ----------------- TEMP: (WIP)
             # docker run -it --rm --network=minitwit-network $DOCKER_USERNAME/minitwit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,17 @@ jobs:
       - run:
          name: Deploy to Digital Ocean Server via Docker
          command: |
+           echo "Transferring docker files to production server"
            scp -o StrictHostKeyChecking=no -r ./dockerfiles/ ${MT_USER}@${MT_SERVER}:/vagrant/
-        #    ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
-        #    "source /root/.bash_profile && \
-        #    cd /minitwit && \
-        #    docker-compose -f ./dockerfiles/ pull && \
-        #    docker-compose -f ./dockerfiles/ up -d"
+
+           echo "Connecting to production server..."
+           ssh -o "StrictHostKeyChecking=no" ${MT_USER}@${MT_SERVER} \
+           "source /root/.bash_profile && \
+           cd /vagrant && \
+
+           echo "Pulling and starting docker containers on server"
+           docker-compose --file ./dockerfiles/docker-compose-deploy.yml pull && \
+           docker-compose --file ./dockerfiles/docker-compose-deploy.yml up -d"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,11 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+
       - add_ssh_keys:
           fingerprints:
             - "d4:22:e0:82:69:3b:81:31:42:e1:68:75:2e:75:4b:d5"
+
       - run: 
           name: Build and push docker images to Dockerhub
           command: |
@@ -46,7 +48,7 @@ jobs:
       - run:
          name: Deploy to Digital Ocean Server via Docker
          command: |
-           scp -o StrictHostKeyChecking=no -r -i ./private/ssh_keys/mskk-digital-ocean-ssh ./dockerfiles/ root@46.101.215.40:/vagrant/
+           scp -o StrictHostKeyChecking=no -r ./dockerfiles/ ${MT_USER}@${MT_SERVER}:/vagrant/
         #    ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
         #    "source /root/.bash_profile && \
         #    cd /minitwit && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 jobs:
-  Run tests on circleCI server:
+  build:
+    name: Run tests on circleCI test server
     docker:
         - image: circleci/node
     steps:
@@ -20,11 +21,11 @@ jobs:
             echo "Setting up environment and running py-tests...."
             echo "yes" | docker-compose -f ./dockerfiles/docker-compose-test.yml up -d
 
-  Deploy to digital ocean:
+  deploy:
     docker:
-      - image: cimg/base:2020.01
+        - image: cimg/base:2020.01
     branches:
-      - release
+        - deployment_from_release
     steps:
       - checkout
       - setup_remote_docker
@@ -43,7 +44,7 @@ jobs:
             echo "Pushing images..."
             docker push $DOCKER_USERNAME/minitwit-app:latest
 
-     - run:
+      - run:
          name: Deploy to Digital Ocean Server via Docker
          command: |
            scp -r ./dockerfiles/* ${MT_USER}@${MT_SERVER}:/minitwit/dockerfiles/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,54 @@ jobs:
           command: |
             echo "Setting up environment and running py-tests...."
             echo "yes" | docker-compose -f ./dockerfiles/docker-compose-test.yml up -d
+
+
+    # ----------------- TEMP: (WIP)
+            # docker run -it --rm --network=minitwit-network $DOCKER_USERNAME/minitwit-tests
+
+    #   - run: 
+    #       name: Build and push to Dockerhub
+    #       command: |
+    #         echo "Login"
+    #         echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+
+    #         echo "Build app"
+    #         docker build -t $DOCKER_USERNAME/minitwit-app . -f Dockerfile-minitwit
+    #         docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
+
+    #         echo "Push"
+    #         docker push $DOCKER_USERNAME/minitwit-app
+    #         docker push $DOCKER_USERNAME/minitwit-tests
+
+
+    #         # docker build -t $DOCKER_USERNAME/minitwit-app -f Dockerfile-minitwit .
+    #         # docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
+
+    # ----------------- OLD:
+    #   - run:
+    #       name: Build and push Docker image
+    #       command: |
+    #         echo "LOGIN"
+    #         echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+    #         echo "BUILD"
+    #         docker build -t $DOCKER_USERNAME/minitwit-app:latest . -f Dockerfile-minitwit
+    #         docker build -t $DOCKER_USERNAME/minitwit-mysql:latest . -f Dockerfile-mysql
+    #         echo "PUSH"
+    #         docker push $DOCKER_USERNAME/minitwit-app:latest
+    #         docker push $DOCKER_USERNAME/minitwit-mysql:latest
+    #   - run:
+    #       name: Run pytest on build server
+    #       command: |
+    #         echo "Running Py tests...."
+    #         docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
+    #         echo "yes" | docker-compose up -d
+    #         docker run -it --rm --network=itu-minitwit-network $DOCKER_USERNAME/minitwit-tests
+
+    #  - run:
+    #      name: Deploy app to Digital Ocean Server via Docker
+    #      command: |
+    #        ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
+    #        "source /root/.bash_profile && \
+    #        cd /vagrant && \
+    #        docker-compose pull && \
+    #        docker-compose up -d"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
 
            echo "Pulling and starting docker containers on server"
            docker-compose --file dockerfiles/docker-compose-deploy.yml pull && \
+           docker-compose --file dockerfiles/docker-compose-deploy.yml down"
            docker-compose --file dockerfiles/docker-compose-deploy.yml up -d"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
            cd /vagrant && \
 
            echo "Pulling and starting docker containers on server"
-           docker-compose --file ./dockerfiles/docker-compose-deploy.yml pull && \
-           docker-compose --file ./dockerfiles/docker-compose-deploy.yml up -d"
+           docker-compose --file dockerfiles/docker-compose-deploy.yml pull && \
+           docker-compose --file dockerfiles/docker-compose-deploy.yml up -d"
 
 workflows:
   version: 2
@@ -71,55 +71,3 @@ workflows:
           filters:
             branches:
               only: deployment_from_release
-
-
-
-    # ----------------- TEMP: (WIP)
-            # docker run -it --rm --network=minitwit-network $DOCKER_USERNAME/minitwit-tests
-
-    #   - run: 
-    #       name: Build and push to Dockerhub
-    #       command: |
-    #         echo "Login"
-    #         echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-
-    #         echo "Build app"
-    #         docker build -t $DOCKER_USERNAME/minitwit-app . -f Dockerfile-minitwit
-    #         docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
-
-    #         echo "Push"
-    #         docker push $DOCKER_USERNAME/minitwit-app
-    #         docker push $DOCKER_USERNAME/minitwit-tests
-
-
-    #         # docker build -t $DOCKER_USERNAME/minitwit-app -f Dockerfile-minitwit .
-    #         # docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
-
-    # ----------------- OLD:
-    #   - run:
-    #       name: Build and push Docker image
-    #       command: |
-    #         echo "LOGIN"
-    #         echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-    #         echo "BUILD"
-    #         docker build -t $DOCKER_USERNAME/minitwit-app:latest . -f Dockerfile-minitwit
-    #         docker build -t $DOCKER_USERNAME/minitwit-mysql:latest . -f Dockerfile-mysql
-    #         echo "PUSH"
-    #         docker push $DOCKER_USERNAME/minitwit-app:latest
-    #         docker push $DOCKER_USERNAME/minitwit-mysql:latest
-    #   - run:
-    #       name: Run pytest on build server
-    #       command: |
-    #         echo "Running Py tests...."
-    #         docker build -t $DOCKER_USERNAME/minitwit-tests -f Dockerfile-minitwit-tests .
-    #         echo "yes" | docker-compose up -d
-    #         docker run -it --rm --network=itu-minitwit-network $DOCKER_USERNAME/minitwit-tests
-
-    #  - run:
-    #      name: Deploy app to Digital Ocean Server via Docker
-    #      command: |
-    #        ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
-    #        "source /root/.bash_profile && \
-    #        cd /vagrant && \
-    #        docker-compose pull && \
-    #        docker-compose up -d"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
          name: Deploy to Digital Ocean Server via Docker
          command: |
-           scp -r ./dockerfiles/* ${MT_USER}@${MT_SERVER}:/minitwit/dockerfiles/ \
+           scp -o StrictHostKeyChecking=no -r -i ./private/ssh_keys/mskk-digital-ocean-ssh ./dockerfiles/ root@46.101.215.40:/vagrant/
         #    ssh -o "StrictHostKeyChecking no" ${MT_USER}@${MT_SERVER} \
         #    "source /root/.bash_profile && \
         #    cd /minitwit && \

--- a/dockerfiles/docker-compose-deploy.yml
+++ b/dockerfiles/docker-compose-deploy.yml
@@ -1,0 +1,22 @@
+version: '3.3'
+
+volumes: 
+    db-data:
+    db-data-backup:
+
+networks:
+  main:
+
+services:
+
+minitwit-app:
+  image: $DOCKER_USERNAME/minitwit-app
+  container_name: minitwit-app
+  networks:
+    - main
+  ports:
+    - '5000:5000'
+    - '5001:5001'
+  volumes:
+    - db-data:/minitwit/data/
+    - db-data-backup:/minitwit/db-data-backup/

--- a/dockerfiles/docker-compose-deploy.yml
+++ b/dockerfiles/docker-compose-deploy.yml
@@ -8,15 +8,14 @@ networks:
   main:
 
 services:
-
-minitwit-app:
-  image: $DOCKER_USERNAME/minitwit-app
-  container_name: minitwit-app
-  networks:
-    - main
-  ports:
-    - '5000:5000'
-    - '5001:5001'
-  volumes:
-    - db-data:/minitwit/data/
-    - db-data-backup:/minitwit/db-data-backup/
+  minitwit-app:
+    image: $DOCKER_USERNAME/minitwit-app
+    container_name: minitwit-app
+    networks:
+      - main
+    ports:
+      - '5000:5000'
+      - '5001:5001'
+    volumes:
+      - db-data:/minitwit/data/
+      - db-data-backup:/minitwit/db-data-backup/

--- a/dockerfiles/docker-compose-test.yml
+++ b/dockerfiles/docker-compose-test.yml
@@ -3,8 +3,7 @@ version: '3.5'
 services:
   minitwit-app:
     network_mode: host
-    # image: $DOCKER_USERNAME/minitwit-app
-    image: mskkitu/minitwit-app
+    image: $DOCKER_USERNAME/minitwit-app
     container_name: minitwit-app
     ports:
       - '5000:5000'
@@ -12,8 +11,7 @@ services:
 
   minitwit-sim-tests:
     network_mode: host
-    # image: $DOCKER_USERNAME/minitwit-tests
-    image: mskkitu/minitwit-tests
+    image: $DOCKER_USERNAME/minitwit-tests
     container_name: minitwit-tests
     depends_on: 
       - minitwit-app

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.3'
+
+networks:
+  main:
+
+services:
+
+  minitwitimage:
+    image: ${DOCKER_USERNAME}/minitwitimage
+    container_name: minitwit
+    networks:
+      - main
+    depends_on:
+      - itusqlimage
+    ports:
+        - '5000:5000'
+
+  itusqlimage:
+    image: ${DOCKER_USERNAME}/mysqlimage
+    container_name: minitwit_mysql
+    networks:
+      - main
+    ports:
+      - '3306:3306'
+    environment:
+        - MYSQL_ROOT_PASSWORD=root


### PR DESCRIPTION
This PR sets up a continous delivery pipeline all the way to our production server on Digital Ocean. The deployment only happens when pushes are made to the release branch. The flow is as follows:
1. Our code is pushed to GitHub
2. CircleCI pulls our code base, builds and tests
3. If the code is pushed to our release branch, then the fresh docker images are pushed to Dockerhub before the needed docker files are uploaded to our production server which pulls them down and creates a docker container that spins up our server. Inside the docker container the directories that contain the database are made into docker volumes which persist the data between runs of the container. This of course needs to be verified, and a backup system should be implemented asap. Ses