### PR TITLE
Scalability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
 
            echo 'Pulling and starting docker containers on server' && \
            cd dockerfiles/ && \
+           ./migrate.sh
            ./run.sh pull && \
            ./run.sh setup_run_app && \
            ./run.sh monitor -d && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
 
            echo 'Pulling and starting docker containers on server' && \
            cd dockerfiles/ && \
-           ./migrate.sh
+           ./migrate.sh && \
            ./run.sh pull && \
            ./run.sh setup_run_app && \
            ./run.sh monitor -d && \

--- a/database.md
+++ b/database.md
@@ -1,0 +1,35 @@
+# Database
+This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean. The server is running on IP `46.101.215.40` and the container is listening on port `5432`.
+
+To acces it run:
+`ssh -i ssh_keys/ssh-key root@46.101.215.40`
+where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
+
+To start the database/container, ssh to the server and, run:
+`Docker-compose up -d`
+
+To wipe the database clean and fresh, ssh to the server and run:
+`./clean`
+This will stop the container, prune all docker containers and volumes, and start a fresh container.
+
+To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:
+`./restore`
+Note: The container has to be running and clean (for easy cleaning, see above)
+
+### Migration
+The following explains how to migrate the database from our current server to this new server: 
+We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on this server, and runs the `restore.sh` script. 
+For the migration to happen smoothly, all we need is to do is to 2 thigs: 
+1. change the database path in the app to reference this server instead, and 
+2. change the `deploy` script to run the .migrate.sh script, before restarting the app.
+This will ensure that this new database is started with the newest possible data, before the app starts referencing this new database. This way, we ensure as little downtime as possible. 
+**NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
+
+### What we did to set it up:
+We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. In order to access it, you therefore need the private ssh key. (It would have been better to do this setup with a Vagrant file, to avoid the following manual ssh'ing and installation on the server.)
+
+To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
+
+Then we uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
+
+We then added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 

--- a/database.md
+++ b/database.md
@@ -32,10 +32,15 @@ This will ensure that this new database is started with the newest possible data
 **NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
 
 ### What we did to set everything up:
+**Adding a new server**
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. In order to access it, you therefore need the private ssh key. (It would have been better to do this setup with a Vagrant file, to avoid the following manual ssh'ing and installation on the server.)
 
 To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
+**Spinning up the container**
 Then we uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
 
-We then added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 
+**Enabling migration**
+We added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 
+
+Lastly we added the `migrate.sh` script to the old server, which will migrate data from the old server to this and run the restore script. Make sure to run `clean.sh` before running the migration. 

--- a/database.md
+++ b/database.md
@@ -17,7 +17,7 @@ This will stop the container, prune all docker containers and volumes, and start
 
 To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:  
 `./restore`  
-Note: The container has to be running and clean (for easy cleaning, see above)
+*Note*: The container has to be running and clean! (for easy cleaning, see above)
 
 ### Migration
 The following explains how to migrate the database from our current server to this new server: 

--- a/database.md
+++ b/database.md
@@ -22,7 +22,7 @@ To restore the database from a .tar file, add the file to the server as `/db_bac
 ### Migration
 The following explains how to migrate the database from our current server to this new server:
 
-We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on this server, and lastly ssh'es into this server to run the `restore.sh` script. 
+We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on the new server, and runs the `restore.sh` script. 
 
 For a smooth migration, now all we need to do is the following two 2 things: 
 1. change the database path in the app to reference this server instead, and 

--- a/database.md
+++ b/database.md
@@ -33,9 +33,7 @@ This will ensure that this new database is started with the newest possible data
 
 ### What we did to set everything up:
 **Adding a new server**  
-We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.)
-
-To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
+We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.) To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
 **Spinning up the container**  
 Then we uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.

--- a/database.md
+++ b/database.md
@@ -1,5 +1,5 @@
 # Database
-This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean.   
+The new database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean.   
 Server is running on IP `46.101.215.40`.  
 Container is listening on port `5432`.
 

--- a/database.md
+++ b/database.md
@@ -1,26 +1,19 @@
 # Database
 This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean. The server is running on IP `46.101.215.40` and the container is listening on port `5432`.
 
-To acces it run:
-
-`ssh -i ssh_keys/ssh-key root@46.101.215.40`
-
+To acces it run:  
+`ssh -i ssh_keys/ssh-key root@46.101.215.40`  
 where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
 
-To start the database/container, ssh to the server and, run:
+To start the database/container, ssh to the server and, run:  
+`Docker-compose up -d`  
 
-`Docker-compose up -d`
-
-To wipe the database clean and fresh, ssh to the server and run:
-
-`./clean`
-
+To wipe the database clean and fresh, ssh to the server and run:  
+`./clean`  
 This will stop the container, prune all docker containers and volumes, and start a fresh container.
 
-To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:
-
-`./restore`
-
+To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:  
+`./restore`  
 Note: The container has to be running and clean (for easy cleaning, see above)
 
 ### Migration

--- a/database.md
+++ b/database.md
@@ -1,6 +1,6 @@
 # Database
 This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean.   
-Server is running on IP `46.101.215.40`.
+Server is running on IP `46.101.215.40`.  
 Container is listening on port `5432`.
 
 ### Commands

--- a/database.md
+++ b/database.md
@@ -2,18 +2,18 @@
 This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean. The server is running on IP `46.101.215.40` and the container is listening on port `5432`.
 
 To acces it run:
-`ssh -i ssh_keys/ssh-key root@46.101.215.40`
+```ssh -i ssh_keys/ssh-key root@46.101.215.40```
 where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
 
 To start the database/container, ssh to the server and, run:
-`Docker-compose up -d`
+```Docker-compose up -d```
 
 To wipe the database clean and fresh, ssh to the server and run:
-`./clean`
+```./clean```
 This will stop the container, prune all docker containers and volumes, and start a fresh container.
 
 To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:
-`./restore`
+```./restore```
 Note: The container has to be running and clean (for easy cleaning, see above)
 
 ### Migration
@@ -23,6 +23,7 @@ For the migration to happen smoothly, all we need is to do is to 2 thigs:
 1. change the database path in the app to reference this server instead, and 
 2. change the `deploy` script to run the .migrate.sh script, before restarting the app.
 This will ensure that this new database is started with the newest possible data, before the app starts referencing this new database. This way, we ensure as little downtime as possible. 
+
 **NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
 
 ### What we did to set it up:

--- a/database.md
+++ b/database.md
@@ -36,7 +36,7 @@ This will ensure that this new database is started with the newest possible data
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.) To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
 **Spinning up the container**  
-Then we uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
+We uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
 
 **Enabling migration**  
 We added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 

--- a/database.md
+++ b/database.md
@@ -1,42 +1,42 @@
 # Database
-The new database is a basic Postgress Docker container running on its own droplet (server) on Digital Ocean.   
-Server is on IP `46.101.215.40`.  
+The new database is a basic Postgress Docker container running on its own droplet (server) on Digital Ocean.
+Server is on IP `64.225.111.21`.
 Container is listening on port `5432`.
 
 ### Commands
-To acces the server run:  
-`ssh -i ssh_keys/ssh-key root@46.101.215.40`  
+To acces the server run:
+`ssh -i ssh_keys/ssh-key root@64.225.111.21`
 where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
 
-To start the database/container, ssh to the server and, run:  
-`Docker-compose up -d`  
+To start the database/container, ssh to the server and, run:
+`Docker-compose up -d`
 
-To wipe the database clean and fresh, ssh to the server and run:  
-`./clean`  
+To wipe the database clean and fresh, ssh to the server and run:
+`./clean`
 This will stop the container, prune all docker containers and volumes, and start a fresh container.
 
-To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:  
-`./restore`  
+To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:
+`./restore`
 *Note*: The container has to be running and clean! (for easy cleaning, see above)
 
 ### Migration
 The following explains how to migrate the database from our current server to this new server:
 
-We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on the new server, and runs the `restore.sh` script. 
+We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on the new server, and runs the `restore.sh` script.
 
-For a smooth migration, now all we need to do is the following two 2 things: 
-1. change the database path in the app to reference this server instead, and 
+For a smooth migration, now all we need to do is the following two 2 things:
+1. change the database path in the app to reference this server instead, and
 2. change the `deploy` script to run the .migrate.sh script, before restarting the app.
-This will ensure that this new database is started with the newest possible data, before the app starts referencing this new database. This way, we ensure as little downtime as possible. 
+This will ensure that this new database is started with the newest possible data, before the app starts referencing this new database. This way, we ensure as little downtime as possible.
 
 **NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
 
 ### What we did to set everything up:
-**Adding a new server**  
+**Adding a new server**
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.) To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
-**Spinning up the container**  
+**Spinning up the container**
 We uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables. The setup ensures that the postgress container has the same name, user and port expected by our application.
 
-**Enabling migration**  
-To start the container with exisitng data we created `clean.sh`  and `restore.sh` scripts. The first starts a freash container with clean volumes. The latter loads data into the cleaned container, from a .tar file in `/db_backup/db-backup.tar`. Lastly we added the `migrate.sh` script to the old server, which will migrate data to the new server and run the restore script. Make sure to run `clean.sh` on the new server, before running the migration. 
+**Enabling migration**
+To start the container with exisitng data we created `clean.sh`  and `restore.sh` scripts. The first starts a freash container with clean volumes. The latter loads data into the cleaned container, from a .tar file in `/db_backup/db-backup.tar`. Lastly we added the `migrate.sh` script to the old server, which will migrate data to the new server and run the restore script. Make sure to run `clean.sh` on the new server, before running the migration.

--- a/database.md
+++ b/database.md
@@ -32,15 +32,15 @@ This will ensure that this new database is started with the newest possible data
 **NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
 
 ### What we did to set everything up:
-**Adding a new server**
+**Adding a new server**  
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. In order to access it, you therefore need the private ssh key. (It would have been better to do this setup with a Vagrant file, to avoid the following manual ssh'ing and installation on the server.)
 
 To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
-**Spinning up the container**
+**Spinning up the container**  
 Then we uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
 
-**Enabling migration**
+**Enabling migration**  
 We added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 
 
 Lastly we added the `migrate.sh` script to the old server, which will migrate data from the old server to this and run the restore script. Make sure to run `clean.sh` before running the migration. 

--- a/database.md
+++ b/database.md
@@ -1,6 +1,6 @@
 # Database
 The new database is a basic Postgress Docker container running on its own droplet (server) on Digital Ocean.   
-Server is running on IP `46.101.215.40`.  
+Server is on IP `46.101.215.40`.  
 Container is listening on port `5432`.
 
 ### Commands

--- a/database.md
+++ b/database.md
@@ -39,6 +39,4 @@ We went on Digital Ocean and setup a new droplet, with the same ssh key that is 
 We uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables. The setup ensures that the postgress container has the same name, user and port expected by our application.
 
 **Enabling migration**  
-We added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 
-
-Lastly we added the `migrate.sh` script to the old server, which will migrate data from the old server to this and run the restore script. Make sure to run `clean.sh` before running the migration. 
+To start the container with exisitng data we created `clean.sh`  and `restore.sh` scripts. The first starts a freash container with clean volumes. The latter loads data into the cleaned container, from a .tar file in `/db_backup/db-backup.tar`. Lastly we added the `migrate.sh` script to the old server, which will migrate data to the new server and run the restore script. Make sure to run `clean.sh` on the new server, before running the migration. 

--- a/database.md
+++ b/database.md
@@ -2,18 +2,25 @@
 This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean. The server is running on IP `46.101.215.40` and the container is listening on port `5432`.
 
 To acces it run:
-```ssh -i ssh_keys/ssh-key root@46.101.215.40```
+
+`ssh -i ssh_keys/ssh-key root@46.101.215.40`
+
 where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
 
 To start the database/container, ssh to the server and, run:
-```Docker-compose up -d```
+
+`Docker-compose up -d`
 
 To wipe the database clean and fresh, ssh to the server and run:
-```./clean```
+
+`./clean`
+
 This will stop the container, prune all docker containers and volumes, and start a fresh container.
 
 To restore the database from a .tar file, add the file to the server as `/db_backup/db-backup.tar` and run:
-```./restore```
+
+`./restore`
+
 Note: The container has to be running and clean (for easy cleaning, see above)
 
 ### Migration

--- a/database.md
+++ b/database.md
@@ -20,16 +20,18 @@ To restore the database from a .tar file, add the file to the server as `/db_bac
 *Note*: The container has to be running and clean! (for easy cleaning, see above)
 
 ### Migration
-The following explains how to migrate the database from our current server to this new server: 
-We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on this server, and runs the `restore.sh` script. 
-For the migration to happen smoothly, all we need is to do is to 2 thigs: 
+The following explains how to migrate the database from our current server to this new server:
+
+We have added a `migrate.sh` script to our currently running server, which creates a backup file of the database, copies it to the expected place on this server, and lastly ssh'es into this server to run the `restore.sh` script. 
+
+For a smooth migration, now all we need to do is the following two 2 things: 
 1. change the database path in the app to reference this server instead, and 
 2. change the `deploy` script to run the .migrate.sh script, before restarting the app.
 This will ensure that this new database is started with the newest possible data, before the app starts referencing this new database. This way, we ensure as little downtime as possible. 
 
 **NOTE**: For this migration to work succesfully, it is very important that we run the `clean.sh` script on this server first before deploying! (ensuring that the container is both clean and running before deploying). We have choicen not to add this step as part of the deploy script, as we want to create as little downtime as possible. The more we can do before the deploy the better.
 
-### What we did to set it up:
+### What we did to set everything up:
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. In order to access it, you therefore need the private ssh key. (It would have been better to do this setup with a Vagrant file, to avoid the following manual ssh'ing and installation on the server.)
 
 To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.

--- a/database.md
+++ b/database.md
@@ -33,7 +33,7 @@ This will ensure that this new database is started with the newest possible data
 
 ### What we did to set everything up:
 **Adding a new server**  
-We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. In order to access it, you therefore need the private ssh key. (It would have been better to do this setup with a Vagrant file, to avoid the following manual ssh'ing and installation on the server.)
+We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.)
 
 To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 

--- a/database.md
+++ b/database.md
@@ -1,7 +1,10 @@
 # Database
-This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean. The server is running on IP `46.101.215.40` and the container is listening on port `5432`.
+This database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean.   
+Server is running on IP `46.101.215.40`.
+Container is listening on port `5432`.
 
-To acces it run:  
+### Commands
+To acces the server run:  
 `ssh -i ssh_keys/ssh-key root@46.101.215.40`  
 where `ssk_keys/ssh-key` is the path of the private ssh-key (you know where to find it).
 

--- a/database.md
+++ b/database.md
@@ -1,5 +1,5 @@
 # Database
-The new database is a basic Postgress Docker container running on its own seperate droplet (server) on Digital Ocean.   
+The new database is a basic Postgress Docker container running on its own droplet (server) on Digital Ocean.   
 Server is running on IP `46.101.215.40`.  
 Container is listening on port `5432`.
 

--- a/database.md
+++ b/database.md
@@ -36,7 +36,7 @@ This will ensure that this new database is started with the newest possible data
 We went on Digital Ocean and setup a new droplet, with the same ssh key that is available to our team on Digital Ocean. To access the new server, you therefore need this private ssh key. (Sidenote: It would have been use a Vagrant file to create the droplet, to avoid the following manual ssh'ing and installation on the server.) To setup the server we needed to install `docker` and `docker-compose`. We did this by fetching the private ssh-key and then ssh'ing into the server and installing everything manually, using a random guide on the internet.
 
 **Spinning up the container**  
-We uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables, for setting up a postgress image with the same name, user and port expected by our application.
+We uploaded the same Docker-compose file of our current db, and added a `.env` file with the required variables. The setup ensures that the postgress container has the same name, user and port expected by our application.
 
 **Enabling migration**  
 We added the `restore.sh` script and `clean.sh` script, which enables to startup the database container with data from a .tar file in `/db_backup/db-backup.tar`. 

--- a/dockerfiles/app/docker-compose.test.yml
+++ b/dockerfiles/app/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     container_name: minitwit-app
     restart: always
     environment:
-      NODE_ENV: "production"
+      NODE_ENV: "test"
     ports:
       - '5000:5000'
       - '5001:5001'

--- a/dockerfiles/migrate.sh
+++ b/dockerfiles/migrate.sh
@@ -1,0 +1,24 @@
+BACKUP_LOCATION="/db-backup"        # Default location of where database backups archives are stored
+BACKUP_NAME="db_backup.tar"         # Name of database backup archive
+SSH_KEY="/vagrant/ssh_keys/ssh-key"
+user="root"
+address="64.225.111.21"
+
+migrate() {
+    docker exec minitwit-db bash -c "pg_dump -U embu -F t minitwit-db > $BACKUP_LOCATION/$BACKUP_NAME"
+
+    docker cp minitwit-db:"$BACKUP_LOCATION"/"$BACKUP_NAME" "$BACKUP_LOCATION"/"$BACKUP_NAME"
+
+    # Make sure directories exist
+    ssh -i "$SSH_KEY" "$user"@"$address" "mkdir -p $BACKUP_LOCATION"
+
+    # Transfer data from local to remote
+    rsync -a -zz -P -e "ssh -i $SSH_KEY" "$BACKUP_LOCATION/" "$user"@"$address":"$BACKUP_LOCATION"
+}
+
+restore() {
+    ssh -i "$SSH_KEY" "$user"@"$address" "./restore.sh"
+}
+
+migrate
+restore

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -181,7 +181,7 @@ setup_run_app() {
 }
 
 # Setup and run application and local database
-setup_run_test_app() {
+setup_local_app() {
     echo "Setting up database and nodejs application."
     run_db "-d"
     wait_for 8 "Waiting for database..."
@@ -204,7 +204,7 @@ setup_run_test() {
     fi
 
     echo "Setting up env and running python test..."
-    setup_run_test_app
+    setup_local_app
     run_test
 
     if [ $? -eq 0 ]
@@ -246,6 +246,8 @@ case "$1" in
         setup_run_test ;;
     setup_run_app)
         setup_run_app ;;
+    setup_local_app)
+        setup_local_app ;;
     *)
         echo "Usage:"
         echo "cd ./dockerfiles"
@@ -264,8 +266,9 @@ case "$1" in
         echo "clean                     remove everything to get a clean slate"
         echo "down                      take everything down"
         echo "status                    show status of docker setup"
-        echo "setup_run_app             setup a complete running application incl database"
+        echo "setup_run_app             setup a complete running application using productiondatabase"
         echo "setup_run_test            setup a complete testing setup and run python tests"
+        echo "setup_local_app           setup a complete running application using local db"
         exit 1
         ;;
 esac

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -52,6 +52,13 @@ run_app() {
     docker-compose -f ./app/docker-compose.yml up $1
 }
 
+# Run test_app w/o dependencies
+# arg1: Optional flags to docker-compose
+run_test_app() {
+    echo "Running app..."
+    docker-compose -f ./app_test/docker-compose.yml up $1
+}
+
 # Run python pytest suite w/o dependencies
 run_test() {
     echo "Running test..."
@@ -165,10 +172,20 @@ status() {
     docker network ls
 }
 
-# Setup and run application and database
+# Setup and run application
 setup_run_app() {
     echo "Setting up nodejs application."
     run_app "-d"
+    wait_for 6 "Waiting for application..."
+    echo "Application and database is started sucessfully."
+}
+
+# Setup and run application and local database
+setup_run_test_app() {
+    echo "Setting up database and nodejs application."
+    run_db "-d"
+    wait_for 8 "Waiting for database..."
+    run_test_app "-d"
     wait_for 6 "Waiting for application..."
     echo "Application and database is started sucessfully."
 }
@@ -187,7 +204,7 @@ setup_run_test() {
     fi
 
     echo "Setting up env and running python test..."
-    setup_run_app
+    setup_run_test_app
     run_test
 
     if [ $? -eq 0 ]

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -167,9 +167,7 @@ status() {
 
 # Setup and run application and database
 setup_run_app() {
-    echo "Setting up database and nodejs application."
-    run_db "-d"
-    wait_for 8 "Waiting for database..."
+    echo "Setting up nodejs application."
     run_app "-d"
     wait_for 6 "Waiting for application..."
     echo "Application and database is started sucessfully."

--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -56,7 +56,7 @@ run_app() {
 # arg1: Optional flags to docker-compose
 run_test_app() {
     echo "Running app..."
-    docker-compose -f ./app_test/docker-compose.yml up $1
+    docker-compose -f ./app/docker-compose.test.yml up $1
 }
 
 # Run python pytest suite w/o dependencies

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo 'Error: no test specified' && exit 1",
     "pretest": "eslint ./server/ --ext .js",
     "pytest": "pytest ./server/test/minitwit_sim_api_test.py",
-    "start": "echo 'Running production' && export NODE_ENV=production && nodemon server.js",
+    "start": "echo 'Running production' && nodemon server.js",
     "dev": "echo 'Running development' && export NODE_ENV=dev && nodemon server.js"
   },
   "repository": {

--- a/server/configs.js
+++ b/server/configs.js
@@ -55,9 +55,37 @@ const production = {
 	},
 };
 
+const test = {
+	simulator: {
+		user: 'simulator',
+		pass: 'super_safe!',
+		port: process.env.SIM_PORT || 5001,
+	},
+	app: {
+		name: process.env.APP_NAME,
+		port: process.env.APP_PORT || 5000,
+		environment: process.env.APPLICATION_ENV,
+		logpath: process.env.LOG_PATH,
+	},
+	swagger: {
+		name: 'swagger',
+		port: 9000,
+	},
+	database: {
+		url: 'postgres://embu:magic@minitwit-db:5432/minitwit-db',
+		protocol: 'postgres',
+	},
+	application_logging: {
+		file: process.env.LOG_PATH,
+		level: process.env.LOG_LEVEL || 'info',
+		console: process.env.LOG_ENABLE_CONSOLE || true,
+	},
+};
+
 const config = {
 	dev,
 	production,
+	test,
 };
 
 module.exports = config[env];

--- a/server/configs.js
+++ b/server/configs.js
@@ -45,7 +45,7 @@ const production = {
 		port: 9000,
 	},
 	database: {
-		url: 'postgres://embu:magic@minitwit-db:5432/minitwit-db',
+		url: 'postgres://embu:magic@64.225.111.21:5432/minitwit-db',
 		protocol: 'postgres',
 	},
 	application_logging: {


### PR DESCRIPTION
Adds a migrate script that transfers the current db from our production server to the new database server.
The deploy script calls the migrate script.
./run.sh setup_run_app only starts the app - not the db.
The connectionstring for the db is changed to use the new db server.